### PR TITLE
4 codegenerator missing component class namespaces for componentdependency

### DIFF
--- a/GeneratorTester/ComponentThree.cs
+++ b/GeneratorTester/ComponentThree.cs
@@ -1,0 +1,19 @@
+﻿using Godot.Composition;
+using Godot;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DifferentNamespace;
+
+[Component(typeof(CharacterBody2D))]
+public partial class ComponentThree : Node
+{
+    public override void _Ready()
+    {
+        base._Ready();
+        InitializeComponent();
+    }
+}

--- a/GeneratorTester/GeneratorTester.csproj
+++ b/GeneratorTester/GeneratorTester.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/GeneratorTester/TestComponent.cs
+++ b/GeneratorTester/TestComponent.cs
@@ -1,4 +1,5 @@
-﻿using Godot;
+﻿using DifferentNamespace;
+using Godot;
 using Godot.Composition;
 using System.ComponentModel;
 
@@ -7,6 +8,7 @@ namespace GeneratorTester
     [Component(typeof(CharacterBody2D))]
     [ComponentDependency(typeof(ComponentOne))]
     [ComponentDependency(typeof(ComponentTwo))]
+    [ComponentDependency(typeof(ComponentThree))]
     public partial class TestComponent : Node
     {
         public override void _Ready()

--- a/Godot.Composition.SourceGenerator/Godot.Composition.SourceGenerator.csproj
+++ b/Godot.Composition.SourceGenerator/Godot.Composition.SourceGenerator.csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Godot.Composition/Godot.Composition.csproj
+++ b/Godot.Composition/Godot.Composition.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Godot.NET.Sdk/4.0.2">
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
     <EnableDynamicLoading>true</EnableDynamicLoading>
     <RootNamespace>Godot.Composition</RootNamespace>
-    <AssemblyVersion>1.2.0.0</AssemblyVersion>
-    <FileVersion>1.2.0.0</FileVersion>
+    <AssemblyVersion>1.3.0.0</AssemblyVersion>
+    <FileVersion>1.3.0.0</FileVersion>
     <Title>Godot.Composition</Title>
     <Version>$(AssemblyVersion)</Version>
     <Description>This library provides an approach for doing composition in Godot.</Description>
@@ -14,6 +14,7 @@
     <PackageTags>Godot;Godot4;gamedev;GameDevelopment;C#</PackageTags>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
     <Company>MilkMediaProductions</Company>
+    <AppendTargetFrameworkToOutputPath>True</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <None Include="..\LICENSE">
@@ -35,8 +36,5 @@
       <copyToOutput>true</copyToOutput>
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
-  </ItemGroup>
-  <ItemGroup>
-    <Content Remove="..\package\Godot.Composition.SourceGenerator.dll" />
   </ItemGroup>
 </Project>

--- a/Godot.Composition/Godot.Composition.csproj
+++ b/Godot.Composition/Godot.Composition.csproj
@@ -36,4 +36,7 @@
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>
   </ItemGroup>
+  <ItemGroup>
+    <Content Remove="..\package\Godot.Composition.SourceGenerator.dll" />
+  </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Godot.Composition
-[![NuGet version (Godot.Composition)](https://img.shields.io/badge/nuget-v1.2-blue?style=flat-square)](https://www.nuget.org/packages/Godot.Composition/1.2)
+[![NuGet version (Godot.Composition)](https://img.shields.io/badge/nuget-v1.3-blue?style=flat-square)](https://www.nuget.org/packages/Godot.Composition/1.3)
 
 This library provides a solution for building game entities in Godot through composition over inheritance. Godot's node-based architecture requires some level of inheritance. However, minimizing inheritance and refactoring much of your game's logic into components may go a long way towards cleaner, more reusable code.
 


### PR DESCRIPTION
- Fix issue where namespaces were not specified if a ComponentDependency was not in the same namespace as the Compoonent.
- Add multiple framework targets for maximum flexibility.